### PR TITLE
fixing some defaults vars to be compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ ansible-galaxy install claranet.apache
 | apache_event_threads_per_child              | 25                                         | The number of threads Apache will create for each child process (Event MPM)                           |
 | apache_event_max_clients                    | 400                                        | The maximum number of simultaneous requests that can be handled by a child process (Event MPM)        |
 | apache_event_max_connections_per_child      | 10000                                      | The maximum number of connections a child process can handle before it is terminated (Event MPM)      |
-| apache_remoteip                             | false                                      | Whether remote IP address information should be updated from the X-Forwarded-For header               |
+| apache_logrotate_retention                  | 365                                        | The maximum number of logs file to archive
+| apache_remoteip                             | true                                       | Whether remote IP address information should be updated from the X-Forwarded-For header               |
 | apache_remoteip_header                      | X-Forwarded-For                            | The name of the header containing the remote IP address                                               |
 | apache_remoteip_proxies                     | [127.0.0.1]                                | A list of trusted proxy servers                                                                       |
 | apache_ssl_protocol                         | -SSLv2 -SSLv3 -TLSv1 -TLSv1.1              | A list of SSL protocols that should be disabled                                                       |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ apache_event_max_clients: 400
 apache_event_max_connections_per_child: 10000
 
 # remoteip
-apache_remoteip: false
+apache_remoteip: true
 apache_remoteip_header: X-Forwarded-For
 apache_remoteip_proxies:
   - 127.0.0.1
@@ -95,7 +95,7 @@ apache_logs_directory: "/var/log/{{ _apache_package_name }}/vhosts"
 apache_logrotate_permissions: "644"
 apache_logrotate_user: "root"
 apache_logrotate_group: "root"
-apache_logrotate_retention: "90"
+apache_logrotate_retention: "365"
 apache_logrotate_frequency: "daily"
 apache_logrotate_paths:
   - "/var/log/{{ _apache_package_name }}/*.log"


### PR DESCRIPTION
Fixing some defaults values on apache role.

## Description
Changing to the default following values : 
- apache_logrotate_retention: 90 -> 365
- apache_remoteip: false -> true

## Motivation and Context
To be compliant with locals law

## Types of Changes
- [X] Default values fix (non-breaking change)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
